### PR TITLE
fix: leads full-page reload and delete crash

### DIFF
--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -72,6 +72,43 @@
   </header>
 
   <main class="relative">
-    {@render children()}
+    <svelte:boundary>
+      {@render children()}
+
+      {#snippet pending()}
+        <div class="leader-page">
+          <div class="flex items-center justify-center py-24">
+            <p
+              class="font-mono text-xs font-bold tracking-wider text-neutral-400 uppercase"
+            >
+              Loading…
+            </p>
+          </div>
+        </div>
+      {/snippet}
+
+      {#snippet failed(error, reset)}
+        <div class="leader-page">
+          <div
+            class="mx-auto max-w-sm space-y-4 py-24 text-center"
+          >
+            <p
+              class="font-mono text-xs font-bold tracking-wider text-red-600 uppercase"
+            >
+              Something went wrong
+            </p>
+            <p class="font-mono text-xs text-neutral-500">
+              {error instanceof Error ? error.message : "An unexpected error occurred"}
+            </p>
+            <button
+              onclick={reset}
+              class="bg-primary-500 px-4 py-2 font-mono text-xs font-bold tracking-wider text-white uppercase transition-colors hover:bg-primary-600"
+            >
+              Try again
+            </button>
+          </div>
+        </div>
+      {/snippet}
+    </svelte:boundary>
   </main>
 </div>

--- a/apps/web/src/routes/(app)/layout.test.ts
+++ b/apps/web/src/routes/(app)/layout.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "bun:test";
+
+/**
+ * Structural regression tests for the app layout boundary.
+ *
+ * SvelteKit remote function queries using $derived(await query()) require
+ * a <svelte:boundary> ancestor to handle pending and error states. Without
+ * it, full-page reloads crash because there is no fallback for the async
+ * pending state during hydration.
+ *
+ * These tests ensure the boundary is never accidentally removed.
+ */
+const layoutSource = await Bun.file(
+  new URL("./+layout.svelte", import.meta.url),
+).text();
+
+describe("App layout boundary", () => {
+  it("wraps page content in a svelte:boundary", () => {
+    expect(layoutSource).toContain("<svelte:boundary>");
+    expect(layoutSource).toContain("</svelte:boundary>");
+  });
+
+  it("has a pending snippet for loading state", () => {
+    expect(layoutSource).toContain("{#snippet pending()}");
+  });
+
+  it("has a failed snippet for error recovery", () => {
+    expect(layoutSource).toContain("{#snippet failed(error, reset)}");
+  });
+
+  it("provides a retry button in the failed state", () => {
+    expect(layoutSource).toContain("Try again");
+  });
+
+  it("renders children inside the boundary, not outside", () => {
+    const boundaryStart = layoutSource.indexOf("<svelte:boundary>");
+    const boundaryEnd = layoutSource.indexOf("</svelte:boundary>");
+    const childrenRender = layoutSource.indexOf("{@render children()}");
+
+    expect(childrenRender).toBeGreaterThan(boundaryStart);
+    expect(childrenRender).toBeLessThan(boundaryEnd);
+  });
+});

--- a/apps/web/src/routes/(app)/layout.test.ts
+++ b/apps/web/src/routes/(app)/layout.test.ts
@@ -1,38 +1,37 @@
 import { describe, it, expect } from "bun:test";
 
 /**
- * Structural regression tests for the app layout boundary.
+ * Structural guard tests for the app layout error boundary.
  *
- * SvelteKit remote function queries using $derived(await query()) require
- * a <svelte:boundary> ancestor to handle pending and error states. Without
- * it, full-page reloads crash because there is no fallback for the async
- * pending state during hydration.
+ * The (app) layout wraps all page content in a <svelte:boundary> so that
+ * async `$derived(await query())` calls have proper pending/error fallbacks.
+ * Without the boundary, navigation to a page with an async load can crash
+ * because there is no ancestor to handle the pending or error state.
  *
- * These tests ensure the boundary is never accidentally removed.
+ * These tests read the raw source to verify the boundary is present.
+ * This approach is intentional: the boundary is an architectural requirement
+ * that is difficult to exercise through component rendering alone, and
+ * removing it would silently break the app at runtime.
  */
 const layoutSource = await Bun.file(
-  new URL("./+layout.svelte", import.meta.url),
+  new URL("./+layout.svelte", import.meta.url)
 ).text();
 
-describe("App layout boundary", () => {
-  it("wraps page content in a svelte:boundary", () => {
-    expect(layoutSource).toContain("<svelte:boundary>");
-    expect(layoutSource).toContain("</svelte:boundary>");
+describe("App layout boundary (structural guard)", () => {
+  it("contains a svelte:boundary element", () => {
+    expect(layoutSource).toMatch(/<svelte:boundary>/);
+    expect(layoutSource).toMatch(/<\/svelte:boundary>/);
   });
 
-  it("has a pending snippet for loading state", () => {
-    expect(layoutSource).toContain("{#snippet pending()}");
+  it("provides a pending snippet for loading state", () => {
+    expect(layoutSource).toMatch(/\{#snippet pending\b/);
   });
 
-  it("has a failed snippet for error recovery", () => {
-    expect(layoutSource).toContain("{#snippet failed(error, reset)}");
+  it("provides a failed snippet for error recovery", () => {
+    expect(layoutSource).toMatch(/\{#snippet failed\b/);
   });
 
-  it("provides a retry button in the failed state", () => {
-    expect(layoutSource).toContain("Try again");
-  });
-
-  it("renders children inside the boundary, not outside", () => {
+  it("renders children inside the boundary", () => {
     const boundaryStart = layoutSource.indexOf("<svelte:boundary>");
     const boundaryEnd = layoutSource.indexOf("</svelte:boundary>");
     const childrenRender = layoutSource.indexOf("{@render children()}");

--- a/apps/web/src/routes/(app)/leads/[id]/+page.svelte
+++ b/apps/web/src/routes/(app)/leads/[id]/+page.svelte
@@ -28,7 +28,7 @@
   const deleteForm = deleteLead.enhance(async ({ submit }) => {
     deleteError = null;
     try {
-      await submit();
+      await submit().updates();
       await goto(resolve("/leads"));
     } catch (err) {
       console.error("Failed to delete lead:", err);

--- a/apps/web/src/routes/(app)/leads/[id]/lead-detail.test.ts
+++ b/apps/web/src/routes/(app)/leads/[id]/lead-detail.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { describe, it, expect, mock, beforeEach, spyOn } from "bun:test";
 import { render, screen, waitFor } from "@testing-library/svelte";
 import {
   createFormMock,
@@ -72,7 +72,11 @@ describe("Lead detail page", () => {
     mockGetLeadData.mockClear();
     mockGoto.mockClear();
     mockResolve.mockClear();
-    mockGetLeadData.mockImplementation(() => Promise.resolve(mockLeadData));
+    mockDeleteLead.mockClear();
+    mockGetLeadData.mockImplementation(() =>
+      Promise.resolve(mockLeadData)
+    );
+    mockDeleteLead.mockImplementation(() => Promise.resolve({ ok: true }));
     mockResolve.mockImplementation((path: string) => path);
   });
 
@@ -80,7 +84,7 @@ describe("Lead detail page", () => {
     render(LeadDetailPage, { params: { id: "lead-1" } });
     await waitFor(() => {
       expect(
-        screen.getByRole("heading", { name: "Acme Corp" }),
+        screen.getByRole("heading", { name: "Acme Corp" })
       ).toBeTruthy();
     });
   });
@@ -107,75 +111,78 @@ describe("Lead detail page", () => {
   });
 
   describe("delete lead", () => {
-    it("uses submit().updates() to prevent auto-invalidation", async () => {
+    it("shows confirmation when Delete is clicked", async () => {
       render(LeadDetailPage, { params: { id: "lead-1" } });
 
       await waitFor(() => {
-        expect(screen.getByRole("heading", { name: "Acme Corp" })).toBeTruthy();
+        expect(screen.getByText("Delete")).toBeTruthy();
       });
 
-      // The component calls deleteLead.enhance(callback) during script execution.
-      // Our mock captures this callback in _enhanceCallback.
-      const enhanceCallback = (mockDeleteLead as any)._enhanceCallback;
-      expect(enhanceCallback).not.toBeNull();
+      screen.getByText("Delete").click();
 
-      // Create a mock submit that returns a Promise with .updates() method
-      const mockUpdates = mock(() => Promise.resolve({ ok: true }));
-      const mockSubmit = mock(() => {
-        const p = Promise.resolve({ ok: true });
-        (p as any).updates = mockUpdates;
-        return p;
+      await waitFor(() => {
+        expect(screen.getByText("Confirm Delete")).toBeTruthy();
+        expect(
+          screen.getByText("Delete this lead from all projects?")
+        ).toBeTruthy();
       });
-
-      await enhanceCallback({ submit: mockSubmit });
-
-      // submit() must be called
-      expect(mockSubmit).toHaveBeenCalledTimes(1);
-      // .updates() must be called on the submit result (single-flight mutation)
-      // This prevents SvelteKit from auto-invalidating getLeadData for the deleted lead
-      expect(mockUpdates).toHaveBeenCalledTimes(1);
     });
 
     it("navigates to /leads after successful delete", async () => {
       render(LeadDetailPage, { params: { id: "lead-1" } });
 
       await waitFor(() => {
-        expect(screen.getByRole("heading", { name: "Acme Corp" })).toBeTruthy();
+        expect(screen.getByText("Delete")).toBeTruthy();
       });
 
-      const enhanceCallback = (mockDeleteLead as any)._enhanceCallback;
+      screen.getByText("Delete").click();
 
-      const mockUpdates = mock(() => Promise.resolve({ ok: true }));
-      const mockSubmit = mock(() => {
-        const p = Promise.resolve({ ok: true });
-        (p as any).updates = mockUpdates;
-        return p;
+      await waitFor(() => {
+        expect(screen.getByText("Confirm Delete")).toBeTruthy();
       });
 
-      await enhanceCallback({ submit: mockSubmit });
+      const confirmButton = screen.getByText("Confirm Delete");
+      const form = confirmButton.closest("form")!;
+      form.dispatchEvent(new Event("submit", { bubbles: true }));
 
-      expect(mockGoto).toHaveBeenCalledTimes(1);
-      expect(mockGoto).toHaveBeenCalledWith("/leads");
+      await waitFor(() => {
+        expect(mockGoto).toHaveBeenCalledTimes(1);
+        expect(mockGoto).toHaveBeenCalledWith("/leads");
+      });
     });
 
     it("shows error message when delete fails", async () => {
+      const consoleSpy = spyOn(console, "error").mockImplementation(
+        () => {}
+      );
+      mockDeleteLead.mockImplementation(() =>
+        Promise.reject(new Error("Server error"))
+      );
+
       render(LeadDetailPage, { params: { id: "lead-1" } });
 
       await waitFor(() => {
-        expect(screen.getByRole("heading", { name: "Acme Corp" })).toBeTruthy();
+        expect(screen.getByText("Delete")).toBeTruthy();
       });
 
-      const enhanceCallback = (mockDeleteLead as any)._enhanceCallback;
+      screen.getByText("Delete").click();
 
-      const mockSubmit = mock(() => {
-        const p = Promise.reject(new Error("Server error"));
-        (p as any).updates = () => p;
-        return p;
+      await waitFor(() => {
+        expect(screen.getByText("Confirm Delete")).toBeTruthy();
       });
 
-      await enhanceCallback({ submit: mockSubmit });
+      const confirmButton = screen.getByText("Confirm Delete");
+      const form = confirmButton.closest("form")!;
+      form.dispatchEvent(new Event("submit", { bubbles: true }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Failed to delete lead. Please try again.")
+        ).toBeTruthy();
+      });
 
       expect(mockGoto).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/apps/web/src/routes/(app)/leads/[id]/lead-detail.test.ts
+++ b/apps/web/src/routes/(app)/leads/[id]/lead-detail.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { render, screen, waitFor } from "@testing-library/svelte";
+import {
+  createFormMock,
+  createQueryMock,
+} from "../../../../test-helpers/sveltekit-mocks";
+
+const mockLeadData = {
+  lead: {
+    id: "lead-1",
+    name: "Acme Corp",
+    placeId: "place_123",
+    email: "hello@acme.com",
+    phone: "+1234567890",
+    website: "https://acme.com",
+    address: "123 Main St",
+    googleMapsUrl: "https://maps.google.com/?cid=123",
+    types: ["restaurant"],
+    rating: 4.5,
+    ratingsTotal: 100,
+    businessStatus: "OPERATIONAL",
+    createdAt: new Date("2024-01-01"),
+  },
+  customFieldSections: [
+    {
+      projectId: "proj-1",
+      projectName: "Test Project",
+      fields: [],
+    },
+  ],
+};
+
+const mockGetLeadData = createQueryMock(mockLeadData);
+const mockDeleteLead = createFormMock({ ok: true });
+const mockUpdateLeadCore = createFormMock({ ok: true });
+const mockCreateProjectCustomField = createFormMock({ ok: true });
+const mockUpsertLeadCustomFieldValue = createFormMock({ ok: true });
+
+const mockGoto = mock(() => Promise.resolve());
+const mockResolve = mock((path: string) => path);
+
+mock.module("$lib/remote/leads.remote.js", () => ({
+  getLeadData: mockGetLeadData,
+  deleteLead: mockDeleteLead,
+  updateLeadCore: mockUpdateLeadCore,
+  createProjectCustomField: mockCreateProjectCustomField,
+  upsertLeadCustomFieldValue: mockUpsertLeadCustomFieldValue,
+  getLeads: createQueryMock([]),
+  createManualLead: createFormMock(),
+  getDiscoveryCapabilities: createQueryMock({ hasOpenRouter: false }),
+  discoverLeads: createFormMock(),
+}));
+
+mock.module("$app/navigation", () => ({
+  goto: mockGoto,
+}));
+
+mock.module("$app/paths", () => ({
+  resolve: mockResolve,
+}));
+
+mock.module("$app/server", () => ({
+  query: (fn: (...args: unknown[]) => unknown) => fn,
+  form: () => createFormMock(),
+  getRequestEvent: () => ({}),
+}));
+
+const { default: LeadDetailPage } = await import("./+page.svelte");
+
+describe("Lead detail page", () => {
+  beforeEach(() => {
+    mockGetLeadData.mockClear();
+    mockGoto.mockClear();
+    mockResolve.mockClear();
+    mockGetLeadData.mockImplementation(() => Promise.resolve(mockLeadData));
+    mockResolve.mockImplementation((path: string) => path);
+  });
+
+  it("renders the lead name in heading", async () => {
+    render(LeadDetailPage, { params: { id: "lead-1" } });
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: "Acme Corp" }),
+      ).toBeTruthy();
+    });
+  });
+
+  it("renders breadcrumbs with Leads link", async () => {
+    render(LeadDetailPage, { params: { id: "lead-1" } });
+    await waitFor(() => {
+      expect(screen.getByText("Leads")).toBeTruthy();
+    });
+  });
+
+  it("renders the Google Maps link", async () => {
+    render(LeadDetailPage, { params: { id: "lead-1" } });
+    await waitFor(() => {
+      expect(screen.getByText(/Open in Google Maps/)).toBeTruthy();
+    });
+  });
+
+  it("renders the delete button", async () => {
+    render(LeadDetailPage, { params: { id: "lead-1" } });
+    await waitFor(() => {
+      expect(screen.getByText("Delete")).toBeTruthy();
+    });
+  });
+
+  describe("delete lead", () => {
+    it("uses submit().updates() to prevent auto-invalidation", async () => {
+      render(LeadDetailPage, { params: { id: "lead-1" } });
+
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: "Acme Corp" })).toBeTruthy();
+      });
+
+      // The component calls deleteLead.enhance(callback) during script execution.
+      // Our mock captures this callback in _enhanceCallback.
+      const enhanceCallback = (mockDeleteLead as any)._enhanceCallback;
+      expect(enhanceCallback).not.toBeNull();
+
+      // Create a mock submit that returns a Promise with .updates() method
+      const mockUpdates = mock(() => Promise.resolve({ ok: true }));
+      const mockSubmit = mock(() => {
+        const p = Promise.resolve({ ok: true });
+        (p as any).updates = mockUpdates;
+        return p;
+      });
+
+      await enhanceCallback({ submit: mockSubmit });
+
+      // submit() must be called
+      expect(mockSubmit).toHaveBeenCalledTimes(1);
+      // .updates() must be called on the submit result (single-flight mutation)
+      // This prevents SvelteKit from auto-invalidating getLeadData for the deleted lead
+      expect(mockUpdates).toHaveBeenCalledTimes(1);
+    });
+
+    it("navigates to /leads after successful delete", async () => {
+      render(LeadDetailPage, { params: { id: "lead-1" } });
+
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: "Acme Corp" })).toBeTruthy();
+      });
+
+      const enhanceCallback = (mockDeleteLead as any)._enhanceCallback;
+
+      const mockUpdates = mock(() => Promise.resolve({ ok: true }));
+      const mockSubmit = mock(() => {
+        const p = Promise.resolve({ ok: true });
+        (p as any).updates = mockUpdates;
+        return p;
+      });
+
+      await enhanceCallback({ submit: mockSubmit });
+
+      expect(mockGoto).toHaveBeenCalledTimes(1);
+      expect(mockGoto).toHaveBeenCalledWith("/leads");
+    });
+
+    it("shows error message when delete fails", async () => {
+      render(LeadDetailPage, { params: { id: "lead-1" } });
+
+      await waitFor(() => {
+        expect(screen.getByRole("heading", { name: "Acme Corp" })).toBeTruthy();
+      });
+
+      const enhanceCallback = (mockDeleteLead as any)._enhanceCallback;
+
+      const mockSubmit = mock(() => {
+        const p = Promise.reject(new Error("Server error"));
+        (p as any).updates = () => p;
+        return p;
+      });
+
+      await enhanceCallback({ submit: mockSubmit });
+
+      expect(mockGoto).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/test-helpers/sveltekit-mocks.ts
+++ b/apps/web/src/test-helpers/sveltekit-mocks.ts
@@ -17,19 +17,32 @@ export function createFormMock(returnValue: unknown = { error: null }) {
           issues: () => null,
         };
       },
-    },
+    }
   );
 
-  const addFormApi = (target: (...args: unknown[]) => unknown) =>
+  const addFormApi = <T extends (...args: unknown[]) => unknown>(
+    target: T
+  ) =>
     Object.assign(target, {
       for: () => addFormApi(mock(() => Promise.resolve(returnValue))),
       pending: 0,
-      enhance: (cb?: (...args: unknown[]) => unknown) => {
-        if (cb) (target as any)._enhanceCallback = cb;
-        return { action: "?/action", method: "POST" };
-      },
+      enhance: (cb?: (...args: unknown[]) => unknown) => ({
+        action: "?/action",
+        method: "POST",
+        onsubmit: async (e: Event) => {
+          e.preventDefault();
+          if (cb) {
+            const submit = () => {
+              const result = target() as Promise<unknown>;
+              return Object.assign(result, {
+                updates: () => result,
+              });
+            };
+            await cb({ submit });
+          }
+        },
+      }),
       fields: fieldProxy,
-      _enhanceCallback: null as ((...args: unknown[]) => unknown) | null,
     });
 
   return addFormApi(fn);
@@ -45,7 +58,9 @@ export function createQueryMock(returnValue: unknown = []) {
 /**
  * Creates a mock for SvelteKit remote `command()` functions.
  */
-export function createCommandMock(returnValue: unknown = { success: true }) {
+export function createCommandMock(
+  returnValue: unknown = { success: true }
+) {
   return mock(() => Promise.resolve(returnValue));
 }
 

--- a/apps/web/src/test-helpers/sveltekit-mocks.ts
+++ b/apps/web/src/test-helpers/sveltekit-mocks.ts
@@ -14,22 +14,22 @@ export function createFormMock(returnValue: unknown = { error: null }) {
         if (prop === "set") return () => {};
         return {
           as: () => ({ name: "field", value: "" }),
+          issues: () => null,
         };
       },
     },
   );
 
-  const enhanceFn = () => ({
-    action: "?/action",
-    method: "POST",
-  });
-
   const addFormApi = (target: (...args: unknown[]) => unknown) =>
     Object.assign(target, {
       for: () => addFormApi(mock(() => Promise.resolve(returnValue))),
       pending: 0,
-      enhance: enhanceFn,
+      enhance: (cb?: (...args: unknown[]) => unknown) => {
+        if (cb) (target as any)._enhanceCallback = cb;
+        return { action: "?/action", method: "POST" };
+      },
       fields: fieldProxy,
+      _enhanceCallback: null as ((...args: unknown[]) => unknown) | null,
     });
 
   return addFormApi(fn);


### PR DESCRIPTION
Add <svelte:boundary> to the app layout to handle async pending/error states for remote function queries. Without this boundary, pages using $derived(await query()) would fail on full-page reload because there was nothing to catch the pending state during hydration.

Fix lead deletion crash by using submit().updates() (single-flight mutation with no queries) instead of bare submit(). The default auto-invalidation was re-running getLeadData() for the just-deleted lead, causing a 404 error before goto() could navigate away.