### PR TITLE
chore: add Renovate repository configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,27 +4,48 @@
   "dependencyDashboard": true,
   "rangeStrategy": "auto",
   "separateMajorMinor": true,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/ci\\.yml$/"],
+      "matchStrings": [
+        "bun-version:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?",
+        "bun-v(?<currentValue>[^\"'\\s]+)"
+      ],
+      "depNameTemplate": "bun",
+      "packageNameTemplate": "bun",
+      "datasourceTemplate": "npm"
+    }
+  ],
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 4am on monday"]
   },
   "packageRules": [
     {
+      "description": "Group Bun runtime updates across package metadata, CI, and Docker",
+      "matchPackageNames": ["bun", "@types/bun", "oven/bun"],
+      "groupName": "bun runtime"
+    },
+    {
       "description": "Group non-major Bun workspace dependency updates",
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchPackageNames": ["!bun", "!@types/bun"],
       "groupName": "bun workspace dependencies"
     },
     {
       "description": "Group GitHub Actions updates",
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchPackageNames": ["!bun"],
       "groupName": "github actions"
     },
     {
       "description": "Group Docker image updates",
       "matchManagers": ["dockerfile", "docker-compose"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchPackageNames": ["!oven/bun"],
       "groupName": "docker images"
     }
   ]


### PR DESCRIPTION
## Summary
- add a root Renovate config so the org-installed GitHub App can manage Bun workspace dependencies in this monorepo
- group Bun runtime updates together across `bun`, `@types/bun`, the CI Bun version pins, and the `oven/bun` Docker base image
- group other non-major package, GitHub Actions, and Docker updates separately while keeping major upgrades isolated and CI as the merge gate