### PR TITLE
chore: remove release version validation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,15 +37,6 @@ jobs:
             echo "is_latest=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Verify version matches package.json
-        run: |
-          PKG_VERSION=$(jq -r '.version' apps/web/package.json)
-          TAG_VERSION="${{ steps.version.outputs.version }}"
-          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "::error::Tag version ($TAG_VERSION) does not match apps/web/package.json version ($PKG_VERSION)"
-            exit 1
-          fi
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ bun run db:studio     # Open Drizzle Studio
 Docker images are published automatically when you push a git tag:
 
 ```bash
-# Tag a release (uses apps/web/package.json version)
+# Tag a release
 git tag web@0.1.0
 git push origin web@0.1.0
 ```

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@leader/web",
   "private": true,
-  "version": "0.2.4",
   "type": "module",
   "scripts": {
     "dev": "vite dev",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@leader/auth",
   "private": true,
-  "version": "0.0.0",
   "type": "module",
   "exports": {
     ".": "./src/auth.ts",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@leader/db",
   "private": true,
-  "version": "0.0.0",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@leader/eslint-config",
   "private": true,
-  "version": "0.0.1",
   "type": "module",
   "exports": {
     ".": "./index.js"

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@leader/logging",
   "private": true,
-  "version": "0.0.0",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@leader/tailwind-config",
   "private": true,
-  "version": "0.0.1",
   "type": "module",
   "main": "./tailwind.config.ts",
   "types": "./tailwind.config.ts",

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@leader/typescript-config",
-  "version": "0.0.0",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@leader/ui",
   "private": true,
-  "version": "0.0.1",
   "type": "module",
   "svelte": "./src/index.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- remove `version` fields from workspace `package.json` files so releases are no longer coupled to package manifest versions
- drop the publish workflow check that required the `web@...` tag to match `apps/web/package.json`
- update the release docs to describe tag-based publishing without referencing package versions

## Testing
- bun run test